### PR TITLE
Added Buffer support

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 "use strict";
 
 var ECMA_SIZES  = require('./byte_size');
+var Buffer = require('buffer').Buffer;
 
 /**
  * Main module's entry point

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "author": "Andrei Karpushonak",
   "license": "MIT",
   "readmeFilename": "README.md",
-  "dependencies": {},
+  "dependencies": {
+    "buffer": "^5.0.5"
+  },
   "devDependencies": {
     "mocha": "^3.0.2",
     "should": "^11.1.0"


### PR DESCRIPTION
Environments that don't have Buffer support like React-Native can now use object-sizeof