### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 'use strict'
 
 var ECMA_SIZES = require('./byte_size')
-var Buffer = require('buffer').Buffer
+var Buffer = require('buffer/').Buffer
 
 function allProperties(obj) {
   const stringProperties = []


### PR DESCRIPTION
As mentioned in doc of buffer
To require this module explicitly, use require('buffer/') which tells the node.js module lookup algorithm (also used by browserify) to use the npm module named buffer instead of the node.js core module named buffer!