### PR TITLE
Changed 'buffer' import to 'buffer/' while requiring 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "object-sizeof",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "Sizeof of a JavaScript object in Bytes",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@
 
 var should = require('should')
 var sizeof = require('../index')
+const Buffer = require('buffer/').Buffer
 
 describe('sizeof', function () {
   it('should handle null in object keys', function () {


### PR DESCRIPTION
Changed 'buffer' import to 'buffer/' while requiring  because earlier it was importing Buffer Module from Nodejs but we need to import from buffer dependency npm module