### PR TITLE
more precise string measurement for node platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@
 var ECMA_SIZES = require('./byte_size')
 var Buffer = require('buffer/').Buffer
 
+var isNodePlatform =  typeof process === "object" && typeof require === "function";
+
 function allProperties(obj) {
   const stringProperties = []
   for (var prop in obj) { 
@@ -58,7 +60,8 @@ function getCalculator (seen) {
     var objectType = typeof (object)
     switch (objectType) {
       case 'string':
-        return object.length * ECMA_SIZES.STRING
+        // https://stackoverflow.com/questions/68789144/how-much-memory-do-v8-take-to-store-a-string/68791382#68791382
+        return isNodePlatform ? 12 + 4 * Math.ceil(object.length/4) : object.length * ECMA_SIZES.STRING
       case 'boolean':
         return ECMA_SIZES.BOOLEAN
       case 'number':


### PR DESCRIPTION
Internally, V8 stores strings using 1 byte per ASCII char with an additional 12 byte header. The size of any heap object must be a multiple of the pointer size, i.e. a multiple of 4, so the size of the string is rounded up to that; the last few bytes may be unused. Therefore the size of a string is calculated the following way: `12 + 4 * Math.ceil(n/4)`. Source: https://stackoverflow.com/questions/68789144/how-much-memory-do-v8-take-to-store-a-string/68791382#68791382

Of course, this is not true in other javascript runtimes, so it's better to use the default approximation in that case. There is no surefire way to detect node runtime, but looking at `process` and `require` objects will give us a good idea. Source: https://www.geeksforgeeks.org/how-to-check-the-current-runtime-environment-is-a-browser-in-javascript/