### PR TITLE
Added support for typed arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Please note that this function will only work in some cases, especially when dea
 - Set
 - BigInt
 - Function
+- Typed Arrays (Int8Array, Uint32Array, Float64Array, etc)
 
 ### Coding standards
 
@@ -40,10 +41,12 @@ Having this knowledge, the module calculates how much memory object will allocat
 ### Examples
 
 ```javascript
-import sizeof from 'object-sizeof'
-// const sizeof = require("object-sizeof")
-console.log("Object { abc: 'def' } in bytes: " + sizeof({ abc: 'def' })) // "Object { abc: 'def' } in bytes: 13"
-console.log('Integer 12345 in bytes: ' + sizeof(12345)) // "Integer 12345 in bytes: 8"
+// import sizeof from 'object-sizeof'
+const sizeof = require('object-sizeof')
+const sizeObj = sizeof({ abc: 'def' })
+console.log(`Size of the object: ${sizeObj} bytes`)
+const sizeInt = sizeof(12345)
+console.log(`Size of the int: ${sizeInt} bytes`)
 ```
 
 ### Licence

--- a/byte_size.js
+++ b/byte_size.js
@@ -8,5 +8,14 @@ module.exports = {
   STRING: 2,
   BOOLEAN: 4,
   BYTES: 4,
-  NUMBER: 8
+  NUMBER: 8,
+  Int8Array: 1,
+  Uint8Array: 1,
+  Uint8ClampedArray: 1,
+  Int16Array: 2,
+  Uint16Array: 2,
+  Int32Array: 4,
+  Uint32Array: 4,
+  Float32Array: 4,
+  Float64Array: 8
 }

--- a/indexv2.js
+++ b/indexv2.js
@@ -41,6 +41,23 @@ function objectSizeComplex (obj) {
       // convert the set to an array
       potentialConversion = Array.from(obj)
     }
+    if (obj instanceof Int8Array) {
+      return obj.length * ECMA_SIZES.Int8Array
+    } else if (obj instanceof Uint8Array || obj instanceof Uint8ClampedArray) {
+      return obj.length * ECMA_SIZES.Uint8Array
+    } else if (obj instanceof Int16Array) {
+      return obj.length * ECMA_SIZES.Int16Array
+    } else if (obj instanceof Uint16Array) {
+      return obj.length * ECMA_SIZES.Uint16Array
+    } else if (obj instanceof Int32Array) {
+      return obj.length * ECMA_SIZES.Int32Array
+    } else if (obj instanceof Uint32Array) {
+      return obj.length * ECMA_SIZES.Uint32Array
+    } else if (obj instanceof Float32Array) {
+      return obj.length * ECMA_SIZES.Float32Array
+    } else if (obj instanceof Float64Array) {
+      return obj.length * ECMA_SIZES.Float64Array
+    }
     const objectToString = JSON.stringify(potentialConversion)
     const buffer = new Buffer.from(objectToString)
     totalSize = buffer.byteLength

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "object-sizeof",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Sizeof of a JavaScript object in Bytes",
   "main": "indexv2.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -95,8 +95,25 @@ describe('sizeof node.js tests', () => {
   it('typed array support', () => {
     const arrayInt8Array = new Int8Array([1, 2, 3, 4, 5])
     sizeof(arrayInt8Array).should.equal(5)
+
+    const arrayUint8Array = new Uint8Array([1, 2, 3, 4, 5])
+    sizeof(arrayUint8Array).should.equal(5)
+
+    const arrayUint16Array = new Uint16Array([1, 2, 3, 4, 5])
+    sizeof(arrayUint16Array).should.equal(10)
+
+    const arrayInt16Array = new Int16Array([1, 2, 3, 4, 5])
+    sizeof(arrayInt16Array).should.equal(10)
+
     const arrayUint32Array = new Uint32Array([1, 2, 3, 4, 5])
     sizeof(arrayUint32Array).should.equal(20)
+
+    const arrayInt32Array = new Int32Array([1, 2, 3, 4, 5])
+    sizeof(arrayInt32Array).should.equal(20)
+
+    const arrayFloat32Array = new Float32Array([1, 2, 3, 4, 5])
+    sizeof(arrayFloat32Array).should.equal(20)
+
     const arrayFloat64 = new Float64Array([1, 2, 3, 4, 5])
     sizeof(arrayFloat64).should.equal(40)
   })

--- a/test/test.js
+++ b/test/test.js
@@ -92,6 +92,15 @@ describe('sizeof node.js tests', () => {
     sizeof(biggerSet).should.be.above(sizeof(smallerSet))
   })
 
+  it('typed array support', () => {
+    const arrayInt8Array = new Int8Array([1, 2, 3, 4, 5])
+    sizeof(arrayInt8Array).should.equal(5)
+    const arrayUint32Array = new Uint32Array([1, 2, 3, 4, 5])
+    sizeof(arrayUint32Array).should.equal(20)
+    const arrayFloat64 = new Float64Array([1, 2, 3, 4, 5])
+    sizeof(arrayFloat64).should.equal(40)
+  })
+
   it('BigInt support', () => {
     sizeof(BigInt(21474836480)).should.equal(11)
   })


### PR DESCRIPTION
Fixes https://github.com/miktam/sizeof/issues/53

The size of a typed array in JavaScript depends on the type of the array. Each element in a typed array takes up a certain number of bytes. The sizes of different typed arrays in JavaScript are as follows:

    Int8Array: 1 byte per element
    Uint8Array: 1 byte per element
    Uint8ClampedArray: 1 byte per element
    Int16Array: 2 bytes per element
    Uint16Array: 2 bytes per element
    Int32Array: 4 bytes per element
    Uint32Array: 4 bytes per element
    Float32Array: 4 bytes per element
    Float64Array: 8 bytes per element