### PR TITLE
import buffer polyfill only if needed

### DIFF
--- a/indexv2.js
+++ b/indexv2.js
@@ -2,7 +2,7 @@
 /* eslint-disable new-cap */ // to fix new Buffer.from
 'use strict'
 const ECMA_SIZES = require('./byte_size')
-const Buffer = require('buffer/').Buffer
+const Buffer = typeof window !== 'undefined' ? require('buffer/').Buffer : global.Buffer
 
 /**
  * Precisely calculate size of string in node


### PR DESCRIPTION
Buffer polyfill is considerably slower than the one built in node. 
When I try to get the size of the following object `{ a: 1, b: 2, c: 3, d: { a: 1, b: 2, c: 3, d: { a: 1, b: 2, c: 3, d: { a: 1, b: 2, c: 3 } } } }` one million times (1_000_000) in node 20 it takes `1817ms` with the polyfill and `1197ms` without. 

I'm proposing to import the polyfill only when running in browser to speed up the calculation in node environment. 